### PR TITLE
Add homepage and bugs.url package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "type": "git",
     "url": "https://github.com/LuminescentDev/lucide-icons-qwik.git"
   },
+  "homepage": "https://github.com/saboooor/lucide-icons-qwik#readme",
+  "bugs": {
+    "url": "https://github.com/saboooor/lucide-icons-qwik/issues"
+  },
   "license": "LICENSE",
   "keywords": [
     "icon",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `lucide-icons-qwik`
- updates only `package.json`

## Metadata added
- `homepage`: `https://github.com/saboooor/lucide-icons-qwik#readme`
- `bugs.url`: `https://github.com/saboooor/lucide-icons-qwik/issues`

## Validation
- parsed `package.json` as JSON after the change
- confirmed the manifest still has `name: lucide-icons-qwik`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.